### PR TITLE
 Fixed typo of missing closing '}' bracket

### DIFF
--- a/STLBASICS/GameFileMapping.cpp
+++ b/STLBASICS/GameFileMapping.cpp
@@ -46,6 +46,5 @@ int main(int argc, char* argv[]) {
       std::cout << "Player: " << pair.first << " Rank: " << pair.second << std::endl;
     }
   }
-
   return 0;
 }


### PR DESCRIPTION
 On branch STLBASICS20260525
	modified:   GameFileMapping.cpp